### PR TITLE
perf(rar50): copy matches in runs, not one byte at a time

### DIFF
--- a/crates/rars/src/codec/rar50.rs
+++ b/crates/rars/src/codec/rar50.rs
@@ -1810,14 +1810,28 @@ impl Unpack50Decoder {
         {
             return Err(Error::InvalidData("RAR 5 match exceeds output limit"));
         }
-        for _ in 0..length {
+        let mut remaining = length;
+        while remaining > 0 {
             if distance <= output.len() {
-                let index = output.len() - distance;
-                output.push(output[index]);
+                // The match lies entirely in already-decoded output: copy in
+                // runs rather than one byte at a time.
+                if distance == 1 {
+                    // A one-byte repeat is a fill, not a copy.
+                    let b = output[output.len() - 1];
+                    output.resize(output.len() + remaining, b);
+                    remaining = 0;
+                } else {
+                    let start = output.len() - distance;
+                    let take = remaining.min(distance);
+                    output.extend_from_within(start..start + take);
+                    remaining -= take;
+                }
             } else {
                 let history_distance = distance - output.len();
                 let index = self.history.len() - history_distance;
-                output.push(self.history[index]);
+                let take = remaining.min(history_distance);
+                output.extend_from_slice(&self.history[index..index + take]);
+                remaining -= take;
             }
         }
         Ok(())


### PR DESCRIPTION
`Unpack50Decoder::copy_match` pushed one byte per iteration, each with a branch and two bounds checks. This replaces that with bulk copies:

- `resize` when the distance is 1 — a one-byte repeat is a fill, not a copy;
- `extend_from_within` for the common case where the match lies in already-decoded output;
- `extend_from_slice` for the part that comes from history.

### Measurement

One 49.4 MB text member decoded into a sink, in-process, no disk, on Apple Silicon. Median of 7, three consecutive invocations per branch:

| | master | this branch |
|---|---|---|
| `-m3` | 302–311 MB/s | **366–369 MB/s** (+19%) |
| `-m5` | 360–365 MB/s | **461–477 MB/s** (+29%) |

In a `sample` profile of the `-m3` case, `copy_match` fell from 29.8% of samples to 6.7% plus honest `memmove`.

### Correctness

`cargo test --release --workspace`: 947 pass, unchanged by this commit.

One test, `rejects_output_path_that_is_existing_symlink` in `crates/rars-cli/tests/cli.rs:514`, fails identically on a pristine `master` checkout here — `Os { code: 17, kind: AlreadyExists }` when creating the symlink, which looks like leftover state between runs rather than anything to do with this change. Mentioning it in case it is news; happy to open a separate issue.

### Context

I maintain an extraction engine that currently reaches RAR through `libunrar` over FFI, and I have been measuring what it would take to move to a pure-Rust decoder. `rars` decodes byte-for-byte identically to `unar` on everything I have thrown at it, including encrypted and multi-volume archives — the only thing keeping me on the C library is throughput on large members. This is the first of what I found while profiling; I am glad to send the rest as separate PRs if that is useful.