### PR TITLE
fix: don't assume a case sensitive filesystem in symlink test

### DIFF
--- a/crates/rars-cli/tests/cli.rs
+++ b/crates/rars-cli/tests/cli.rs
@@ -5,7 +5,7 @@ use rars::crc32::crc32;
 use rars::rar13::{write_stored_archive, StoredEntry, WriterOptions};
 use rars::rar15_40;
 use std::fs;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, UNIX_EPOCH};
@@ -508,7 +508,13 @@ fn rejects_output_path_that_is_existing_symlink() {
     fs::create_dir_all(&out_dir).unwrap();
     fs::write(&target, b"do not overwrite\n").unwrap();
     std::os::unix::fs::symlink(&target, out_dir.join("link.txt")).unwrap();
-    std::os::unix::fs::symlink(&target, out_dir.join("LINK.TXT")).unwrap();
+    // Same path on a case insensitive filesystem, so EEXIST is fine here:
+    // the entry still extracts onto a symlink.
+    match std::os::unix::fs::symlink(&target, out_dir.join("LINK.TXT")) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(err) => panic!("failed to create upper case symlink: {err}"),
+    }
     let bytes = write_stored_archive(
         &[StoredEntry {
             name: b"link.txt",


### PR DESCRIPTION
`cargo test --workspace` fails on a clean checkout on macOS:

```
thread 'rejects_output_path_that_is_existing_symlink' panicked at
crates/rars-cli/tests/cli.rs:511:67:
called `Result::unwrap()` on an `Err` value:
Os { code: 17, kind: AlreadyExists, message: "File exists" }
```

The test symlinks both `out/link.txt` and `out/LINK.TXT`. Those are two paths on a case sensitive filesystem and one path otherwise, so the second `symlink()` returns EEXIST. APFS is case insensitive by default.

Treating EEXIST as satisfied keeps the test running on macOS rather than skipping it there. The archive entry is `link.txt`, which lands on a symlink either way, so the assertions below are unchanged.

macOS 27.0 / APFS, rustc 1.97.1: `cargo test --workspace --all-targets --locked` gives 1305 pass, 0 fail.
